### PR TITLE
Migrate to API v2, update tracking event and code clean up

### DIFF
--- a/class-gfklaviyofeedaddon.php
+++ b/class-gfklaviyofeedaddon.php
@@ -93,9 +93,14 @@ class GFKlaviyoAPI extends GFFeedAddOn {
 			));
 			
 			//If the Klaviyo API returns a code anything other than OK, log it!
-			if($response['response']['code'] != 200) {
-				$this->log_error( __METHOD__ . '(): Could not add user to mailing list' );
-				$this->log_error( __METHOD__ . '(): response => ' . print_r( $response, true ) );
+			if ( is_wp_error( $response ) ) {
+				$this->log_error( __METHOD__ . '(): Could not add user to mailing list. ' . $response->get_error_message() );
+			}
+			else {
+				if($response['response']['code'] != 200) {
+					$this->log_error( __METHOD__ . '(): Could not add user to mailing list' );
+					$this->log_error( __METHOD__ . '(): response => ' . print_r( $response, true ) );
+				}
 			}
         }
 	}

--- a/class-gfklaviyofeedaddon.php
+++ b/class-gfklaviyofeedaddon.php
@@ -248,23 +248,18 @@ class GFKlaviyoAPI extends GFFeedAddOn {
         $private_key = $this->get_plugin_setting('private_api_key');
 
         if ($private_key) {
-			$url = 'https://a.klaviyo.com/api/v1/lists?api_key=' . $private_key;
+			$url = 'https://a.klaviyo.com/api/v2/lists?api_key=' . $private_key;
 	       	$response = wp_remote_get($url);
 
-	       	$data = json_decode($response['body']);
-
-            /* Get available Klaviyo lists. */
-	        $ac_lists = $data->data;
+	       	$data = json_decode($response['body']);	    
 
 	        /* Add Klaviyo lists to array and return it. */
 	        $lists = array();
-            foreach ( $ac_lists as $list ) {
-                if ($list->list_type == 'list') {
-                    $lists[] = array(
-                        'label' => $list->name,
-                        'value' => $list->id
-                    );
-                }
+            foreach ( $data as $list ) {
+				$lists[] = array(
+					'label' => $list->list_name,
+					'value' => $list->list_id
+				);                
             }
         }
 

--- a/class-gfklaviyofeedaddon.php
+++ b/class-gfklaviyofeedaddon.php
@@ -27,22 +27,6 @@ class GFKlaviyoAPI extends GFFeedAddOn {
 		return self::$_instance;
 	}
 
-	/**
-	 * Plugin starting point. Handles hooks, loading of language files and PayPal delayed payment support.
-	 */
-	public function init() {
-
-		parent::init();
-
-		$this->add_delayed_payment_support (
-			array(
-				'option_label' => esc_html__( 'Subscribe contact to service x only when payment is received.', 'klaviyoaddon' )
-			)
-		);
-
-	}
-
-
 	// # FEED PROCESSING -----------------------------------------------------------------------------------------------
 
 	/**

--- a/class-gfklaviyofeedaddon.php
+++ b/class-gfklaviyofeedaddon.php
@@ -54,12 +54,17 @@ class GFKlaviyoAPI extends GFFeedAddOn {
 
 		}
 
-		// Send the values to the third-party service.
+		// Send a custom event to show the form was interacted with 
         if ($this->get_plugin_setting('api_key')) {
             $tracker = new Klaviyo($this->get_plugin_setting('api_key'));
             $tracker->track (
-                'Active on Site',
-                array('$email' => $merge_vars['email'], '$first_name' => $merge_vars['first_name'], '$last_name' => $merge_vars['last_name'])
+                'GravityForm Submitted',
+                array(
+					'$email' => $merge_vars['email']
+				),
+				array(
+					'Form' => $form['title']
+				)
             );
         }
 

--- a/class-gfklaviyofeedaddon.php
+++ b/class-gfklaviyofeedaddon.php
@@ -98,28 +98,6 @@ class GFKlaviyoAPI extends GFFeedAddOn {
         }
 	}
 
-	/**
-	 * Custom format the phone type field values before they are returned by $this->get_field_value().
-	 *
-	 * @param array $entry The Entry currently being processed.
-	 * @param string $field_id The ID of the Field currently being processed.
-	 * @param GF_Field_Phone $field The Field currently being processed.
-	 *
-	 * @return string
-	 */
-	public function get_phone_field_value( $entry, $field_id, $field ) {
-
-		// Get the field value from the Entry Object.
-		$field_value = rgar( $entry, $field_id );
-
-		// If there is a value and the field phoneFormat setting is set to standard reformat the value.
-		if ( ! empty( $field_value ) && $field->phoneFormat == 'standard' && preg_match( '/^\D?(\d{3})\D?\D?(\d{3})\D?(\d{4})$/', $field_value, $matches ) ) {
-			$field_value = sprintf( '%s-%s-%s', $matches[1], $matches[2], $matches[3] );
-		}
-
-		return $field_value;
-	}
-
 	// # ADMIN FUNCTIONS -----------------------------------------------------------------------------------------------
 
 

--- a/class-gfklaviyofeedaddon.php
+++ b/class-gfklaviyofeedaddon.php
@@ -163,13 +163,11 @@ class GFKlaviyoAPI extends GFFeedAddOn {
 							),
 							array(
                                 'name'     => 'first_name',
-                                'label'    => esc_html__( 'First Name', 'klaviyoaddon' ),
-                                'required' => true
+                                'label'    => esc_html__( 'First Name', 'klaviyoaddon' )
                             ),
                             array(
                                 'name'     => 'last_name',
-                                'label'    => esc_html__( 'Last Name', 'klaviyoaddon' ),
-                                'required' => true
+                                'label'    => esc_html__( 'Last Name', 'klaviyoaddon' )
                             ),
 						),
 					),

--- a/includes/Klaviyo.php
+++ b/includes/Klaviyo.php
@@ -12,6 +12,15 @@ class Klaviyo {
         $this->api_key = $api_key;
     }
     
+    /**
+     * Sends tracking event for the associated user
+     *
+     * @param string    $event                  Name of the event.
+     * @param array     $customer_properties    Custom information about the person who did this event.
+     * @param array     $properties             Custom information about this event.
+     * @param int       $timestamp              UNIX timestamp for when this event occurred.
+     * @return boolean                          True if the request was successful.
+     */
     function track($event, $customer_properties=array(), $properties=array(), $timestamp=NULL) {
         if ((!array_key_exists('$email', $customer_properties) || empty($customer_properties['$email']))
             && (!array_key_exists('$id', $customer_properties) || empty($customer_properties['$id']))) {


### PR DESCRIPTION
We require a Klaviyo plugin for Gravity Forms, however some code changes were required. I set the name fields as optional, and now only post them to Klaviyo f they are set. The tracking event was changed from "Active on Site" to "GravityForm Submitted" as I felt this was more descriptive, the form name is also sent along with the event. I changed the subscription POST request to use the v2 API, and removed some functions from the sample code.